### PR TITLE
trying to make room for v9958 support

### DIFF
--- a/src/transball-auxiliar.asm
+++ b/src/transball-auxiliar.asm
@@ -139,6 +139,11 @@ HL_NOT_SMALLER_THAN_BC:
     ret
 	
 ;-----------------------------------------------
+; SUB HL,BC and divide by 16 HL
+sub_HL_BC_divide_HL_by_16:
+	xor a
+	sbc hl,bc
+;-----------------------------------------------
 ; divide by 16 HL
 divide_HL_by_16: 
 	ld a,h

--- a/src/transball-auxiliar.asm
+++ b/src/transball-auxiliar.asm
@@ -137,6 +137,36 @@ HL_NOT_SMALLER_THAN_BC:
     ld h,b
     ld l,c
     ret
+	
+;-----------------------------------------------
+; divide by 16 HL
+divide_HL_by_16: 
+	ld a,h
+	and a
+	jp m,divide_HL_by_16_neg
+    rrca	
+    rr l
+    rrca
+    rr l
+    rrca
+    rr l
+    rrca
+    rr l
+	and 15
+	ld h,a
+	ret
+divide_HL_by_16_neg:
+    rrca	
+    rr l
+    rrca
+    rr l
+    rrca
+    rr l
+    rrca
+    rr l
+	or 0F0h
+	ld h,a
+	ret
 ;-----------------------------------------------
 ; outi 32 times HL 
 outi32:

--- a/src/transball-enemies.asm
+++ b/src/transball-enemies.asm
@@ -392,28 +392,15 @@ enemyUpdateCycle_DirectionalCannon_fireBullet_foundSlot:
     ld b,(ix+6)    ;; enemy y
     xor a
     sbc hl,bc
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    ex de,hl
+	call divide_HL_by_16
+	ex de,hl
     ld hl,(shipposition+2)
     ld c,(ix+7)    ;; enemy x
     ld b,(ix+8)    ;; enemy x
     xor a
     sbc hl,bc   
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l    ;; now we have (ship.x - enemy.x) in hl, and (ship.y - enemy.y) in de (in pixels)
+	call divide_HL_by_16
+    ;; now we have (ship.x - enemy.x) in hl, and (ship.y - enemy.y) in de (in pixels)
 
     ld b,l
     ld c,e
@@ -775,14 +762,7 @@ tankUpdateCycle_updateCanon_fireBullet:
 
     xor a
     sbc hl,bc
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
+	call divide_HL_by_16
     ex de,hl
     ld hl,(shipposition+2)
     ld b,(ix+4) ;; tank x
@@ -793,14 +773,8 @@ tankUpdateCycle_updateCanon_fireBullet:
 
     xor a
     sbc hl,bc   
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l    ;; now we have (ship.x - enemy.x) in hl, and (ship.y - enemy.y) in de (in pixels)
+	call divide_HL_by_16
+	;; now we have (ship.x - enemy.x) in hl, and (ship.y - enemy.y) in de (in pixels)
 
     ld b,l
     ld c,e

--- a/src/transball-enemies.asm
+++ b/src/transball-enemies.asm
@@ -390,16 +390,12 @@ enemyUpdateCycle_DirectionalCannon_fireBullet_foundSlot:
     ld hl,(shipposition)
     ld c,(ix+5)    ;; enemy y
     ld b,(ix+6)    ;; enemy y
-    xor a
-    sbc hl,bc
-	call divide_HL_by_16
+	call sub_HL_BC_divide_HL_by_16
 	ex de,hl
     ld hl,(shipposition+2)
     ld c,(ix+7)    ;; enemy x
     ld b,(ix+8)    ;; enemy x
-    xor a
-    sbc hl,bc   
-	call divide_HL_by_16
+	call sub_HL_BC_divide_HL_by_16
     ;; now we have (ship.x - enemy.x) in hl, and (ship.y - enemy.y) in de (in pixels)
 
     ld b,l
@@ -760,9 +756,7 @@ tankUpdateCycle_updateCanon_fireBullet:
     sra b   ;; divide by 2 (so that it's actually multiplied by 128)
     rr c
 
-    xor a
-    sbc hl,bc
-	call divide_HL_by_16
+	call sub_HL_BC_divide_HL_by_16
     ex de,hl
     ld hl,(shipposition+2)
     ld b,(ix+4) ;; tank x
@@ -771,9 +765,7 @@ tankUpdateCycle_updateCanon_fireBullet:
     sra b   ;; divide by 2 (so that it's actually multiplied by 128)
     rr c
 
-    xor a
-    sbc hl,bc   
-	call divide_HL_by_16
+	call sub_HL_BC_divide_HL_by_16
 	;; now we have (ship.x - enemy.x) in hl, and (ship.y - enemy.y) in de (in pixels)
 
     ld b,l

--- a/src/transball-gameloop.asm
+++ b/src/transball-gameloop.asm
@@ -119,7 +119,6 @@ Time_is_up_Loop:
     ;; draw  text
     ld hl,NAMTBL2+32*10
     call SETWRT
-    ex de,hl
     ld hl,Time_is_up_text
 	call outi32
     call SFX_INT

--- a/src/transball-gfx.asm
+++ b/src/transball-gfx.asm
@@ -12,10 +12,9 @@ drawSprites:
                         ;; set to 0 (otherwise, we would see garbage when we move the scroll with 
                         ;; register r23).
     call SETWRT
-    ex de,hl
+    
     ld hl,thruster_spriteattributes
-    ld b,4+4+4+MAX_PLAYER_BULLETS*4+MAX_ENEMY_BULLETS*4
-    ld c,VDP_DATA
+    ld bc,(4+4+4+MAX_PLAYER_BULLETS*4+MAX_ENEMY_BULLETS*4)*256 + VDP_DATA
 drawSprites_loop:
     outi
     jp nz,drawSprites_loop

--- a/src/transball-main-en.asm
+++ b/src/transball-main-en.asm
@@ -17,6 +17,14 @@ Execute:
 
     call VDP_IsTMS9918A
     jr z,Execute_MSX1
+	dec a
+	jr z,Execute_MSX2
+Execute_MSX2_plus:
+    ld a,1
+    ld (isMSX2),a
+    ld (useSmoothScroll),a
+	ld (useSmoothScrollPlus),a
+    jr Execute_Continue
 Execute_MSX2:
     ld a,1
     ld (isMSX2),a
@@ -456,4 +464,6 @@ current_animation_frame:
 isMSX2:
     ds virtual 1
 useSmoothScroll:
+    ds virtual 1
+useSmoothScrollPlus:
     ds virtual 1

--- a/src/transball-maps.asm
+++ b/src/transball-maps.asm
@@ -805,9 +805,7 @@ renderMap:
     ;; render scoreboard:
     ld hl,NAMTBL2
     call SETWRT
-    ex de,hl
     ld hl,scoreboard
-
 	call outi32
 
     ;; calculate the offset in tiles

--- a/src/transball-physics.asm
+++ b/src/transball-physics.asm
@@ -250,15 +250,11 @@ ballPhysics_temporary_collision:
 ballPhysics_ball_no_collision_at_start:
     ld hl,(shipposition)
     ld bc,(ballposition)
-    xor a
-    sbc hl,bc
-	call divide_HL_by_16
+	call sub_HL_BC_divide_HL_by_16
     ex de,hl
     ld hl,(shipposition+2)
     ld bc,(ballposition+2)
-    xor a
-    sbc hl,bc   
-	call divide_HL_by_16
+	call sub_HL_BC_divide_HL_by_16
 	;; now we have (ship.x - ball.x) in hl, and (ship.y - ball.y) in de (in pixels)
 
     ld a,(ballstate)
@@ -461,9 +457,7 @@ ballPhysics_ball_vertical_collision2:
     ;; Vertical 2:
     ld hl,0
     ld bc,(ballvelocity)
-    xor a
-    sbc hl,bc   ;; hl = -(ballvelocity)
-	call divide_HL_by_16
+	call sub_HL_BC_divide_HL_by_16		;; hl = -(ballvelocity)/16
     ld bc,(ballposition)
     add hl,bc
     ld b,h
@@ -497,9 +491,7 @@ ballPhysics_ball_vertical_collision_continue:
     ;; Horizontal 1:
     ld hl,0
     ld bc,(ballvelocity+2)
-    xor a
-    sbc hl,bc   ;; hl = -(ballvelocity+2)
-	call divide_HL_by_16
+   	call sub_HL_BC_divide_HL_by_16	;; hl = -(ballvelocity+2)/16
     ld bc,(ballposition+2)
     add hl,bc
     ld d,h

--- a/src/transball-physics.asm
+++ b/src/transball-physics.asm
@@ -11,15 +11,9 @@ applyGravityAndSpeed:
     call HL_NOT_SMALLER_THAN_BC
     ld (shipvelocity),hl
     ;; add velocity (Y):
-    ex de,hl
-    sra d   ; divide by 16:
-    rr e
-    sra d
-    rr e
-    sra d
-    rr e
-    sra d
-    rr e
+	call divide_HL_by_16
+	ex de,hl
+    
     ld hl,(shipposition)
     add hl,de
     ld bc,(current_map_ship_limits)
@@ -46,16 +40,9 @@ applyGravityAndSpeed_y_continue1:
 applyGravityAndSpeed_y_continue2:
     ld (shipposition),hl
     ;; add velocity (X):
-    ld de,(shipvelocity+2)
-    sra d   ; divide by 16:
-    rr e
-    sra d
-    rr e
-    sra d
-    rr e
-    sra d
-    rr e
-    ld hl,(shipposition+2)
+    ld hl,(shipvelocity+2)
+	call divide_HL_by_16
+    ld de,(shipposition+2)
     add hl,de
     ld bc,(current_map_ship_limits+2)
     push hl
@@ -265,27 +252,14 @@ ballPhysics_ball_no_collision_at_start:
     ld bc,(ballposition)
     xor a
     sbc hl,bc
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
+	call divide_HL_by_16
     ex de,hl
     ld hl,(shipposition+2)
     ld bc,(ballposition+2)
     xor a
     sbc hl,bc   
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l    ;; now we have (ship.x - ball.x) in hl, and (ship.y - ball.y) in de (in pixels)
+	call divide_HL_by_16
+	;; now we have (ship.x - ball.x) in hl, and (ship.y - ball.y) in de (in pixels)
 
     ld a,(ballstate)
     and a   ;; equivalent to cp 0, but faster
@@ -394,16 +368,9 @@ ballPhysics_after_drag:
     call HL_NOT_SMALLER_THAN_BC
     ld (ballvelocity),hl
     ;; add velocity (Y):
-    ld de,(ballvelocity)
-    sra d   ; divide by 16:
-    rr e
-    sra d
-    rr e
-    sra d
-    rr e
-    sra d
-    rr e
-    ld hl,(ballposition)
+    ld hl,(ballvelocity)
+	call divide_HL_by_16
+    ld de,(ballposition)
     add hl,de
     ld bc,(current_map_ship_limits)
     push hl
@@ -431,16 +398,9 @@ ballPhysics_y_continue1:
 ballPhysics_y_continue2:
     ld (ballposition),hl
     ;; add velocity (X):
-    ld de,(ballvelocity+2)
-    sra d   ; divide by 16:
-    rr e
-    sra d
-    rr e
-    sra d
-    rr e
-    sra d
-    rr e
-    ld hl,(ballposition+2)
+    ld hl,(ballvelocity+2)
+	call divide_HL_by_16
+    ld de,(ballposition+2)
     add hl,de
     ld bc,(current_map_ship_limits+2)
     push hl
@@ -487,14 +447,7 @@ ballPhysics_x_continue2:
     ld bc,(ballposition)
     ld de,(ballposition+2)
     ld hl,(ballvelocity)
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l    
+	call divide_HL_by_16
     add hl,bc
     ld b,h
     ld c,l
@@ -510,14 +463,7 @@ ballPhysics_ball_vertical_collision2:
     ld bc,(ballvelocity)
     xor a
     sbc hl,bc   ;; hl = -(ballvelocity)
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l    
+	call divide_HL_by_16
     ld bc,(ballposition)
     add hl,bc
     ld b,h
@@ -553,14 +499,7 @@ ballPhysics_ball_vertical_collision_continue:
     ld bc,(ballvelocity+2)
     xor a
     sbc hl,bc   ;; hl = -(ballvelocity+2)
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l    
+	call divide_HL_by_16
     ld bc,(ballposition+2)
     add hl,bc
     ld d,h
@@ -577,14 +516,7 @@ ballPhysics_ball_horizontal_collision2:
     ld bc,(ballposition)
     ld de,(ballposition+2)
     ld hl,(ballvelocity+2)
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l    
+	call divide_HL_by_16
     add hl,de
     ld d,h
     ld e,l

--- a/src/transball-sprites.asm
+++ b/src/transball-sprites.asm
@@ -20,11 +20,8 @@ changeSprites:
 b1:	outi
 	jp nz,b1
 
-    ; ex de,hl							; remove if THRUSTER_SPRITE always follows SHIP_SPRITE
-    ; ld hl,SPRTBL2+THRUSTER_SPRITE*32	;
-    ; call SETWRT							;
-	; ex de,hl							;
-    
+	; valid only becouse THRUSTER_SPRITE follows SHIP_SPRITE
+	
 	ld bc,shipvpanther_thruster-shipvpanther-32
 	
     add hl,bc
@@ -43,14 +40,13 @@ shipExplosionSprites:
 
     ld hl,SPRTBL2+SHIP_SPRITE*32
     call SETWRT
-    ex de,hl
     ld hl,explosion_sprites_inside
-    ld a,(shipstate)    ;; get the offset of the explosion frame
+    ld a,(shipstate)    		;; get the offset of the explosion frame
     and #f8
     sla a
     sla a
     cp 32*3
-    jp p,clearAllTheSprites ;; we do a "jp", so that when "clearAllTheSprites" is over, we return from this function
+    jp p,clearAllTheSprites 	;; we do a "jp", so that when "clearAllTheSprites" is over, we return from this function
     ld c,a
     ld b,0
     add hl,bc
@@ -58,9 +54,9 @@ shipExplosionSprites:
 
     ld hl,SPRTBL2+THRUSTER_SPRITE*32
     call SETWRT
-    ex de,hl
+    
     ld hl,explosion_sprites_outside
-    ld a,(shipstate)    ;; get the offset of the explosion frame
+    ld a,(shipstate)    		;; get the offset of the explosion frame
     and #f8
     sla a
     sla a
@@ -80,48 +76,26 @@ calculate_ship_sprite_position:
     ld bc,(desired_map_offset)
     xor a
     sbc hl,bc
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    ld a,l
-
+	call divide_HL_by_16
     ;; adjust sprite position based on the smooth scroll offset:
-    ld b,a
     ld a,(desired_vertical_scroll_for_r23)
-    add a,b
+    add a,l
 
     ld (ship_spriteattributes),a
     ld (thruster_spriteattributes),a
 
     ld hl,(shipposition+2)
-    ;; project down to screen coordinates:
-    ; divide by 16:
+    ;; project down to screen coordinates
     ld bc,(desired_map_offset+2)
     xor a
     sbc hl,bc
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    ld a,l
-
+	call divide_HL_by_16
     ;; adjust sprite position based on the smooth scroll offset:
-    ld b,a
     ld a,(desired_horizontal_scroll_for_r18)
-    add a,b
+    add a,l
 
     ld (ship_spriteattributes+1),a
     ld (thruster_spriteattributes+1),a
-
     ret
 
 
@@ -145,18 +119,10 @@ calculate_ball_sprite_position:
     and #80
     ld c,a
 calculate_ball_sprite_position_snap_ball_to_map_y_continue:
-    xor a
-    sbc hl,bc
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    ld a,h  ;; If "h" is anything but 0, that means that the ball is outside of the drawing area
-    and a   ;; equivalent to cp 0, but faster
+    and a
+	sbc hl,bc
+	call divide_HL_by_16
+	;; If "h" is anything but 0, that means that the bullet is outside of the drawing area
     jr nz,calculate_ball_sprite_position_outside_y
     ld a,l
     cp 192
@@ -188,25 +154,15 @@ calculate_ball_sprite_position_y_continue:
     and #80
     ld c,a
 calculate_ball_sprite_position_snap_ball_to_map_x_continue:
-    xor a
-    sbc hl,bc
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    ld a,h  ;; If "h" is anything but 0, that means that the ball is outside of the drawing area
-    and a   ;; equivalent to cp 0, but faster
+    and a
+	sbc hl,bc
+    call divide_HL_by_16
+	;; If "h" is anything but 0, that means that the bullet is outside of the drawing area
     jr nz,calculate_ball_sprite_position_outside_x
-    ld a,l
 
     ;; adjust sprite position based on the smooth scroll offset:
-    ld b,a
     ld a,(desired_horizontal_scroll_for_r18)
-    add a,b
+    add a,l
 
     ld (ball_spriteattributes+1),a
     jp calculate_ball_sprite_position_continue
@@ -254,25 +210,17 @@ calculate_bullet_sprite_positions_loop:
     ;; calculate bullet position
     ;; from: player_bullet_positions to player_bullet_sprite_attributes
     ; y:
+    ld bc,(map_offset)
     ld a,(de)
     ld l,a
     inc de
     ld a,(de)
     ld h,a
     inc de
-    ld bc,(map_offset)
-    xor a
-    sbc hl,bc
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    ld a,h  ;; If "h" is anything but 0, that means that the bullet is outside of the drawing area
-    and a   ;; equivalent to cp 0, but faster
+    and a
+	sbc hl,bc
+   	call divide_HL_by_16
+	;; If "h" is anything but 0, that means that the bullet is outside of the drawing area
     jr nz,calculate_bullet_sprite_positions_bullet_outside_y
     ld a,l
     cp 192
@@ -289,32 +237,22 @@ calculate_bullet_sprite_positions_bullet_outside_y:
     ld (ix),224 ;; just a value that would draw the bullet out of the drawable area
 calculate_bullet_sprite_positions_bullet_outside_y_continue:
     ; x:
+    ld bc,(map_offset+2)
     ld a,(de)
     ld l,a
     inc de
     ld a,(de)
     ld h,a
     inc de
-    ld bc,(map_offset+2)
-    xor a
-    sbc hl,bc
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    ld a,h  ;; If "h" is anything but 0, that means that the bullet is outside of the drawing area
-    and a   ;; equivalent to cp 0, but faster
+    and a
+	sbc hl,bc
+    call divide_HL_by_16
+	;; If "h" is anything but 0, that means that the bullet is outside of the drawing area
     jr nz,calculate_bullet_sprite_positions_bullet_outside_x
-    ld a,l
 
     ;; adjust sprite position based on the smooth scroll offset:
-    ld b,a
     ld a,(desired_horizontal_scroll_for_r18)
-    add a,b
+    add a,l
 
     ld (ix+1),a
     jr calculate_bullet_sprite_positions_bullet_outside_x_continue
@@ -385,26 +323,16 @@ calculate_enemy_bullet_sprite_positions_loop:
     and #80
     ld c,a
 calculate_enemy_bullet_sprite_positions_snap_y_continue:
-    xor a
+    and a
     sbc hl,bc
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    ld a,h  ;; If "h" is anything but 0, that means that the bullet is outside of the drawing area
-    and a   ;; equivalent to cp 0, but faster
+   	call divide_HL_by_16
     jr nz,calculate_enemy_bullet_sprite_positions_bullet_outside_y
     ld a,l
     cp 192
     jr nc,calculate_enemy_bullet_sprite_positions_bullet_outside_y
     ;; adjust sprite position based on the smooth scroll offset:
-    ld b,a
     ld a,(desired_vertical_scroll_for_r23)
-    add a,b
+    add a,l
     ld (ix),a
     jr calculate_enemy_bullet_sprite_positions_bullet_outside_y_continue
 calculate_enemy_bullet_sprite_positions_bullet_outside_y:
@@ -429,22 +357,11 @@ calculate_enemy_bullet_sprite_positions_bullet_outside_y_continue:
 calculate_enemy_bullet_sprite_positions_snap_x_continue:
     xor a
     sbc hl,bc
-    sra h   ; divide by 16:
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l
-    sra h
-    rr l    
-    ld a,h  ;; If "h" is anything but 0, that means that the bullet is outside of the drawing area
-    and a   ;; equivalent to cp 0, but faster
+	call divide_HL_by_16
     jr nz,calculate_enemy_bullet_sprite_positions_bullet_outside_x
-    ld a,l
     ;; adjust sprite position based on the smooth scroll offset:
-    ld b,a
     ld a,(desired_horizontal_scroll_for_r18)
-    add a,b
+    add a,l
     ld (ix+1),a
     jr calculate_enemy_bullet_sprite_positions_bullet_outside_x_continue
 calculate_enemy_bullet_sprite_positions_bullet_outside_x:

--- a/src/transball-sprites.asm
+++ b/src/transball-sprites.asm
@@ -74,9 +74,7 @@ calculate_ship_sprite_position:
     ld hl,(shipposition)
     ;; project down to screen coordinates:
     ld bc,(desired_map_offset)
-    xor a
-    sbc hl,bc
-	call divide_HL_by_16
+	call sub_HL_BC_divide_HL_by_16
     ;; adjust sprite position based on the smooth scroll offset:
     ld a,(desired_vertical_scroll_for_r23)
     add a,l
@@ -87,9 +85,7 @@ calculate_ship_sprite_position:
     ld hl,(shipposition+2)
     ;; project down to screen coordinates
     ld bc,(desired_map_offset+2)
-    xor a
-    sbc hl,bc
-	call divide_HL_by_16
+	call sub_HL_BC_divide_HL_by_16
     ;; adjust sprite position based on the smooth scroll offset:
     ld a,(desired_horizontal_scroll_for_r18)
     add a,l
@@ -119,9 +115,7 @@ calculate_ball_sprite_position:
     and #80
     ld c,a
 calculate_ball_sprite_position_snap_ball_to_map_y_continue:
-    and a
-	sbc hl,bc
-	call divide_HL_by_16
+	call sub_HL_BC_divide_HL_by_16
 	;; If "h" is anything but 0, that means that the bullet is outside of the drawing area
     jr nz,calculate_ball_sprite_position_outside_y
     ld a,l
@@ -154,9 +148,7 @@ calculate_ball_sprite_position_y_continue:
     and #80
     ld c,a
 calculate_ball_sprite_position_snap_ball_to_map_x_continue:
-    and a
-	sbc hl,bc
-    call divide_HL_by_16
+	call sub_HL_BC_divide_HL_by_16
 	;; If "h" is anything but 0, that means that the bullet is outside of the drawing area
     jr nz,calculate_ball_sprite_position_outside_x
 
@@ -217,9 +209,7 @@ calculate_bullet_sprite_positions_loop:
     ld a,(de)
     ld h,a
     inc de
-    and a
-	sbc hl,bc
-   	call divide_HL_by_16
+	call sub_HL_BC_divide_HL_by_16
 	;; If "h" is anything but 0, that means that the bullet is outside of the drawing area
     jr nz,calculate_bullet_sprite_positions_bullet_outside_y
     ld a,l
@@ -244,9 +234,7 @@ calculate_bullet_sprite_positions_bullet_outside_y_continue:
     ld a,(de)
     ld h,a
     inc de
-    and a
-	sbc hl,bc
-    call divide_HL_by_16
+	call sub_HL_BC_divide_HL_by_16
 	;; If "h" is anything but 0, that means that the bullet is outside of the drawing area
     jr nz,calculate_bullet_sprite_positions_bullet_outside_x
 
@@ -323,9 +311,7 @@ calculate_enemy_bullet_sprite_positions_loop:
     and #80
     ld c,a
 calculate_enemy_bullet_sprite_positions_snap_y_continue:
-    and a
-    sbc hl,bc
-   	call divide_HL_by_16
+	call sub_HL_BC_divide_HL_by_16
     jr nz,calculate_enemy_bullet_sprite_positions_bullet_outside_y
     ld a,l
     cp 192
@@ -355,9 +341,7 @@ calculate_enemy_bullet_sprite_positions_bullet_outside_y_continue:
     and #80
     ld c,a
 calculate_enemy_bullet_sprite_positions_snap_x_continue:
-    xor a
-    sbc hl,bc
-	call divide_HL_by_16
+	call sub_HL_BC_divide_HL_by_16
     jr nz,calculate_enemy_bullet_sprite_positions_bullet_outside_x
     ;; adjust sprite position based on the smooth scroll offset:
     ld a,(desired_horizontal_scroll_for_r18)


### PR DESCRIPTION
I moved in a function the division of hl by 16.
This saved some bytes that allowed to add V9958 detection

The plan is to set R25 = 0 in the scorebar and R25 = 2 in the active area
One should also set R27 = 0 in the scorebar and  and R27 = xoffset (in 0-7) in the active area
Sprites stay unaffected by the scroll, so they have to be displaced by the z80
I am halfway, as I stopped  at vdp detection
